### PR TITLE
Support Sinatra 2

### DIFF
--- a/lib/sinatra/param/version.rb
+++ b/lib/sinatra/param/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module Param
-    VERSION = '1.4.0'
+    VERSION = '1.4.1'
   end
 end

--- a/sinatra-param.gemspec
+++ b/sinatra-param.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "Parameter Validation & Type Coercion for Sinatra."
   s.description = "sinatra-param allows you to declare, validate, and transform endpoint parameters as you would in frameworks like ActiveModel or DataMapper."
 
-  s.add_dependency "sinatra", "~> 1.3"
+  s.add_dependency "sinatra", ">= 1.3", "< 3.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Upstream commit doesn't seem to do anything else to support Sinatra 2 https://github.com/mattt/sinatra-param/commit/c4b5d812efb99cab0dba14866159bbe24ce16b80#diff-c213b92775fc24a804248ca7aab5f558. I did opt to at least put an upper limit on Sinatra 3 in case they break their API then.

![](https://i.imgur.com/JnB9NSC.gif)